### PR TITLE
Replace use of each with foreach

### DIFF
--- a/core/components/renderresources/snippet.renderresources.php
+++ b/core/components/renderresources/snippet.renderresources.php
@@ -371,7 +371,7 @@ if (!empty($sortby)) {
         $sorts = array($sortby => $sortdir);
     }
     if (is_array($sorts)) {
-        while (list($sort, $dir) = each($sorts)) {
+        foreach ($sorts as $sort => $dir) {
             if ($sortbyEscaped) $sort = $modx->escape($sort);
             if (!empty($sortbyAlias)) $sort = $modx->escape($sortbyAlias) . ".{$sort}";
             $criteria->sortby($sort, $dir);


### PR DESCRIPTION
As described in issue #6, this snippet breaks in PHP 8 because of the use of each. Replacing it with a `foreach` statement resolves the issue.

Resolves #6